### PR TITLE
Build 0->1

### DIFF
--- a/.ci_support/linux_python2.7.yaml
+++ b/.ci_support/linux_python2.7.yaml
@@ -4,7 +4,7 @@ numpy:
 - '1.9'
 pin_run_as_build:
   python:
-    max_pin: x.x
     min_pin: x.x
+    max_pin: x.x
 python:
 - '2.7'

--- a/.ci_support/linux_python3.5.yaml
+++ b/.ci_support/linux_python3.5.yaml
@@ -4,7 +4,7 @@ numpy:
 - '1.9'
 pin_run_as_build:
   python:
-    max_pin: x.x
     min_pin: x.x
+    max_pin: x.x
 python:
 - '3.5'

--- a/.ci_support/linux_python3.6.yaml
+++ b/.ci_support/linux_python3.6.yaml
@@ -4,7 +4,7 @@ numpy:
 - '1.9'
 pin_run_as_build:
   python:
-    max_pin: x.x
     min_pin: x.x
+    max_pin: x.x
 python:
 - '3.6'

--- a/.ci_support/osx_python2.7.yaml
+++ b/.ci_support/osx_python2.7.yaml
@@ -10,7 +10,7 @@ numpy:
 - '1.9'
 pin_run_as_build:
   python:
-    max_pin: x.x
     min_pin: x.x
+    max_pin: x.x
 python:
 - '2.7'

--- a/.ci_support/osx_python3.5.yaml
+++ b/.ci_support/osx_python3.5.yaml
@@ -10,7 +10,7 @@ numpy:
 - '1.9'
 pin_run_as_build:
   python:
-    max_pin: x.x
     min_pin: x.x
+    max_pin: x.x
 python:
 - '3.5'

--- a/.ci_support/osx_python3.6.yaml
+++ b/.ci_support/osx_python3.6.yaml
@@ -10,7 +10,7 @@ numpy:
 - '1.9'
 pin_run_as_build:
   python:
-    max_pin: x.x
     min_pin: x.x
+    max_pin: x.x
 python:
 - '3.6'

--- a/.ci_support/win_cxx_compilervs2015python3.5.yaml
+++ b/.ci_support/win_cxx_compilervs2015python3.5.yaml
@@ -4,8 +4,8 @@ numpy:
 - '1.11'
 pin_run_as_build:
   python:
-    max_pin: x.x
     min_pin: x.x
+    max_pin: x.x
 python:
 - '3.5'
 zip_keys:

--- a/.ci_support/win_cxx_compilervs2015python3.6.yaml
+++ b/.ci_support/win_cxx_compilervs2015python3.6.yaml
@@ -4,8 +4,8 @@ numpy:
 - '1.11'
 pin_run_as_build:
   python:
-    max_pin: x.x
     min_pin: x.x
+    max_pin: x.x
 python:
 - '3.6'
 zip_keys:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   # Python 2.7 stack is build with too ancient vc9 (VS2008)
   skip: True  # [win and py27]
 


### PR DESCRIPTION
OSX on Python 2.7 failed in SerialIOTest. Can't trigger this individual build myself, unfortunately.

Rerendered feedstock as well with `conda smithy rerender`.