### PR TITLE
Release: 0.6.1a

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,14 +1,14 @@
 {% set name = "openpmd-api" %}
-{% set version = "0.6.0a" %}
-{% set sha256 = "b38e8094caeac94d5b21bc57b379b83e62f0ae8c3e822e05944ff1ad5f231a14" %}
+{% set version = "0.6.1a" %}
+{% set sha256 = "9fc6d5fc9892927d00e8a34c87785b80d9cdb8002047eca6d86423143128fdf6" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: 0.6.0-alpha.tar.gz
-  url: https://github.com/openPMD/openPMD-api/archive/0.6.0-alpha.tar.gz
+  fn: 0.6.1-alpha.tar.gz
+  url: https://github.com/openPMD/openPMD-api/archive/0.6.1-alpha.tar.gz
   sha256: {{ sha256 }}
 
 build:


### PR DESCRIPTION
Python stride checks have been relaxed and one-element n-d arrays are allowed for scalars.