### PR TITLE
AppVeyor: conda-build=3.15

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -40,7 +40,7 @@ install:
 
     # Configure the VM.
     # Tell conda we want an updated version of conda-forge-ci-setup and conda-build
-    - cmd: conda.exe install -n root -c conda-forge --quiet --yes conda-forge-ci-setup=2 conda-build
+    - cmd: conda.exe install -n root -c conda-forge --quiet --yes conda-forge-ci-setup=2 conda-build=3.15
     - cmd: setup_conda_rc .\ .\recipe .\.ci_support\%CONFIG%.yaml
     - cmd: run_conda_forge_build_setup
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ source:
     - 0003-libcpp-adios1.patch
 
 build:
-  number: 3
+  number: 4
   # Python 2.7 stack is build with too ancient vc9 (VS2008)
   skip: True  # [win and py27]
   run_exports:


### PR DESCRIPTION
Downgrade conda-build on AppVeyor to avoid https://github.com/conda/conda-build/issues/3351