### PR TITLE
MPI Variants: Linux

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -10,11 +10,23 @@ jobs:
   strategy:
     maxParallel: 8
     matrix:
-      linux_python3.6target_platformlinux-64:
-        CONFIG: linux_python3.6target_platformlinux-64
+      linux_mpimpichpython3.6target_platformlinux-64:
+        CONFIG: linux_mpimpichpython3.6target_platformlinux-64
         UPLOAD_PACKAGES: True
-      linux_python3.7target_platformlinux-64:
-        CONFIG: linux_python3.7target_platformlinux-64
+      linux_mpimpichpython3.7target_platformlinux-64:
+        CONFIG: linux_mpimpichpython3.7target_platformlinux-64
+        UPLOAD_PACKAGES: True
+      linux_mpinompipython3.6target_platformlinux-64:
+        CONFIG: linux_mpinompipython3.6target_platformlinux-64
+        UPLOAD_PACKAGES: True
+      linux_mpinompipython3.7target_platformlinux-64:
+        CONFIG: linux_mpinompipython3.7target_platformlinux-64
+        UPLOAD_PACKAGES: True
+      linux_mpiopenmpipython3.6target_platformlinux-64:
+        CONFIG: linux_mpiopenmpipython3.6target_platformlinux-64
+        UPLOAD_PACKAGES: True
+      linux_mpiopenmpipython3.7target_platformlinux-64:
+        CONFIG: linux_mpiopenmpipython3.7target_platformlinux-64
         UPLOAD_PACKAGES: True
   steps:
   - script: |

--- a/.ci_support/linux_mpimpichpython3.6target_platformlinux-64.yaml
+++ b/.ci_support/linux_mpimpichpython3.6target_platformlinux-64.yaml
@@ -14,6 +14,8 @@ cxx_compiler_version:
 - '7'
 docker_image:
 - condaforge/linux-anvil-comp7
+mpi:
+- mpich
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_mpimpichpython3.7target_platformlinux-64.yaml
+++ b/.ci_support/linux_mpimpichpython3.7target_platformlinux-64.yaml
@@ -1,30 +1,26 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 VERBOSE_CM:
 - VERBOSE=1
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '4'
+- '7'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '4'
-macos_machine:
-- x86_64-apple-darwin13.4.0
-macos_min_version:
-- '10.9'
+- '7'
+docker_image:
+- condaforge/linux-anvil-comp7
 mpi:
-- nompi
+- mpich
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- '3.6'
+- '3.7'
 target_platform:
-- osx-64
+- linux-64

--- a/.ci_support/linux_mpinompipython3.6target_platformlinux-64.yaml
+++ b/.ci_support/linux_mpinompipython3.6target_platformlinux-64.yaml
@@ -1,23 +1,19 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 VERBOSE_CM:
 - VERBOSE=1
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '4'
+- '7'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '4'
-macos_machine:
-- x86_64-apple-darwin13.4.0
-macos_min_version:
-- '10.9'
+- '7'
+docker_image:
+- condaforge/linux-anvil-comp7
 mpi:
 - nompi
 pin_run_as_build:
@@ -27,4 +23,4 @@ pin_run_as_build:
 python:
 - '3.6'
 target_platform:
-- osx-64
+- linux-64

--- a/.ci_support/linux_mpinompipython3.7target_platformlinux-64.yaml
+++ b/.ci_support/linux_mpinompipython3.7target_platformlinux-64.yaml
@@ -1,23 +1,19 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 VERBOSE_CM:
 - VERBOSE=1
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '4'
+- '7'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '4'
-macos_machine:
-- x86_64-apple-darwin13.4.0
-macos_min_version:
-- '10.9'
+- '7'
+docker_image:
+- condaforge/linux-anvil-comp7
 mpi:
 - nompi
 pin_run_as_build:
@@ -25,6 +21,6 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- '3.6'
+- '3.7'
 target_platform:
-- osx-64
+- linux-64

--- a/.ci_support/linux_mpiopenmpipython3.6target_platformlinux-64.yaml
+++ b/.ci_support/linux_mpiopenmpipython3.6target_platformlinux-64.yaml
@@ -1,25 +1,21 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 VERBOSE_CM:
 - VERBOSE=1
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '4'
+- '7'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '4'
-macos_machine:
-- x86_64-apple-darwin13.4.0
-macos_min_version:
-- '10.9'
+- '7'
+docker_image:
+- condaforge/linux-anvil-comp7
 mpi:
-- nompi
+- openmpi
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -27,4 +23,4 @@ pin_run_as_build:
 python:
 - '3.6'
 target_platform:
-- osx-64
+- linux-64

--- a/.ci_support/linux_mpiopenmpipython3.7target_platformlinux-64.yaml
+++ b/.ci_support/linux_mpiopenmpipython3.7target_platformlinux-64.yaml
@@ -14,6 +14,8 @@ cxx_compiler_version:
 - '7'
 docker_image:
 - condaforge/linux-anvil-comp7
+mpi:
+- openmpi
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_python3.7target_platformosx-64.yaml
+++ b/.ci_support/osx_python3.7target_platformosx-64.yaml
@@ -18,6 +18,8 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
+mpi:
+- nompi
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.6target_platformwin-64.yaml
+++ b/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.6target_platformwin-64.yaml
@@ -8,6 +8,8 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2015
+mpi:
+- nompi
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.7target_platformwin-64.yaml
+++ b/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.7target_platformwin-64.yaml
@@ -8,6 +8,8 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2015
+mpi:
+- nompi
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/README.md
+++ b/README.md
@@ -43,17 +43,45 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_python3.6target_platformlinux-64</td>
+              <td>linux_mpimpichpython3.6target_platformlinux-64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=722&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openpmd-api-feedstock?branchName=master&jobName=linux&configuration=linux_python3.6target_platformlinux-64" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openpmd-api-feedstock?branchName=master&jobName=linux&configuration=linux_mpimpichpython3.6target_platformlinux-64" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_python3.7target_platformlinux-64</td>
+              <td>linux_mpimpichpython3.7target_platformlinux-64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=722&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openpmd-api-feedstock?branchName=master&jobName=linux&configuration=linux_python3.7target_platformlinux-64" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openpmd-api-feedstock?branchName=master&jobName=linux&configuration=linux_mpimpichpython3.7target_platformlinux-64" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_mpinompipython3.6target_platformlinux-64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=722&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openpmd-api-feedstock?branchName=master&jobName=linux&configuration=linux_mpinompipython3.6target_platformlinux-64" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_mpinompipython3.7target_platformlinux-64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=722&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openpmd-api-feedstock?branchName=master&jobName=linux&configuration=linux_mpinompipython3.7target_platformlinux-64" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_mpiopenmpipython3.6target_platformlinux-64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=722&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openpmd-api-feedstock?branchName=master&jobName=linux&configuration=linux_mpiopenmpipython3.6target_platformlinux-64" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_mpiopenmpipython3.7target_platformlinux-64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=722&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openpmd-api-feedstock?branchName=master&jobName=linux&configuration=linux_mpiopenmpipython3.7target_platformlinux-64" alt="variant">
                 </a>
               </td>
             </tr><tr>

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -40,6 +40,18 @@ if [[ ${mpi} == "nompi" ]]; then
 else
     export USE_MPI=ON
 fi
+#   see https://github.com/conda-forge/hdf5-feedstock/blob/master/recipe/mpiexec.sh
+if [[ "$mpi" == "mpich" ]]; then
+    export HYDRA_LAUNCHER=fork
+    #export HYDRA_LAUNCHER=ssh
+fi
+if [[ "$mpi" == "openmpi" ]]; then
+    export OMPI_MCA_btl=self,tcp
+    export OMPI_MCA_plm=isolated
+    #export OMPI_MCA_plm=ssh
+    export OMPI_MCA_rmaps_base_oversubscribe=yes
+    export OMPI_MCA_btl_vader_single_copy_mechanism=none
+fi
 
 cmake \
     -DCMAKE_BUILD_TYPE=Release  \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -61,5 +61,5 @@ cmake \
     ${SRC_DIR}
 
 make ${VERBOSE_CM} -j${CPU_COUNT}
-make ${VERBOSE_CM} test
+CTEST_OUTPUT_ON_FAILURE=1 make ${VERBOSE_CM} test
 make install

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -34,13 +34,20 @@ elif [[ ${CXXFLAGS} == *"-std="* ]]; then
 fi
 
 
+# MPI variants
+if [[ ${mpi} == "nompi" ]]; then
+    export USE_MPI=OFF
+else
+    export USE_MPI=ON
+fi
+
 cmake \
     -DCMAKE_BUILD_TYPE=Release  \
     -DBUILD_SHARED_LIBS=ON      \
     -DCMAKE_CXX_STANDARD=${CXX_STANDARD}      \
     -DCMAKE_CXX_STANDARD_REQUIRED=ON          \
     -DCMAKE_CXX_EXTENSIONS=${CXX_EXTENSIONS}  \
-    -DopenPMD_USE_MPI=OFF       \
+    -DopenPMD_USE_MPI=${USE_MPI}              \
     -DopenPMD_USE_HDF5=ON       \
     -DopenPMD_USE_ADIOS1=ON     \
     -DopenPMD_USE_ADIOS2=OFF    \

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,8 @@
+mpi:
+- nompi
+- mpich    # [linux]
+- openmpi  # [linux]
+
+pin_run_as_build:
+  mpich: x.x
+  openmpi: x.x

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,16 @@
 {% set name = "openpmd-api" %}
 {% set version = "0.8.0a" %}
-{% set build = 2 %}
+{% set build = 3 %}
 {% set version_fn = version.replace("a", "-alpha") %}
 {% set sha256 = "5b2f96850bc65f928b2c250086dd3567e41dbd86686a938c6248155013651ab4" %}
+
+# ensure mpi is defined (needed for conda-smithy recipe-lint)
+{% set mpi = mpi or 'nompi' %}
+
+# prioritize nompi variant via build number
+{% if mpi == 'nompi' %}
+{% set build = build + 100 %}
+{% endif %}
 
 package:
   name: {{ name|lower }}
@@ -16,7 +24,23 @@ source:
 build:
   number: {{ build }}
   skip: True  # [py27]
+
+  # add build string so packages can depend on
+  # mpi or nompi variants
+  # dependencies:
+  # `pkg * mpi_mpich_*` for mpich
+  # `pkg * mpi_*` for any mpi
+  # `pkg * nompi_*` for no mpi
+  {% if mpi == 'nompi' %}
+  {% set mpi_prefix = "nompi" %}
+  {% else %}
+  {% set mpi_prefix = "mpi_" + mpi %}
+  {% endif %}
+  string: "{{ mpi_prefix }}_py{{ py }}h{{ PKG_HASH }}_{{ build }}"
+
   run_exports:
+    # strict runtime dependency on build-time MPI flavor
+    - {{ name }} * {{ mpi_prefix }}_* 
     # https://conda.io/docs/user-guide/tasks/build-packages/variants.html#referencing-subpackages
     # in 0.X.*, newer minor versions are compatible
     - {{ pin_subpackage('openpmd-api', min_pin='x.x', max_pin='x.x') }}
@@ -28,11 +52,15 @@ requirements:
     - make  # [unix]
     - cmake >=3.11
   host:
+    - {{ mpi }}  # [mpi != 'nompi'] 
     - python
     - pybind11 >=2.2.4
-    - adios >=1.13.1  # [unix]
-    - hdf5  >=1.8.13
+    - adios >=1.13.1                    # [unix and mpi == 'nompi']
+    - hdf5  >=1.8.13                    # [mpi == 'nompi']
+    - adios >=1.13.1 = mpi_{{ mpi }}_*  # [unix and mpi != 'nompi']
+    - hdf5  >=1.8.13 = mpi_{{ mpi }}_*  # [mpi != 'nompi']
   run:
+    - {{ mpi }}  # [mpi != 'nompi']
     - python
     - numpy >=1.15.0
     # FIXME: for some reason warnings about this (ADIOS1 deps)


### PR DESCRIPTION
Build three variants:
- nompi (default)
- openmpi
- mpich

Note the following:
- MPI for Windows (MSMPI) is not yet packaged with conda-forge, therefore MPI-support is Unix-only
- MPI runtime tests seam to fail / be misconfigured on OSX; MPI variants for OSX will be enabled in a follow-up PR

Allows users to install the following:

- `conda install openpmd-api` default, nompi variant
- `conda install openpmd-api=*=mpi*` any mpi-compatible implementation
- `conda install openpmd-api=*=mpi_mpich*` pick mpich variant.
  Same result as `conda install mpich openpmd-api=*=mpi*` .
- `conda install openpmd-api=1.13=nompi*` explicitly forbid MPI.
  Usually not necessary, as the build number offset causes `nompi` to be preferred unless MPI is explicitly requested.

Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.
