### PR TITLE
Dep Variant: List Twice (HDF5, ADIOS)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "openpmd-api" %}
 {% set version = "0.9.0a" %}
-{% set build = 0 %}
+{% set build = 1 %}
 {% set version_fn = version.replace("a", "-alpha") %}
 {% set sha256 = "2fd84f276453122b89ce66d4467ec162669315be2c75ae45d2a514d7b96a3a42" %}
 
@@ -55,8 +55,10 @@ requirements:
     - {{ mpi }}  # [mpi != 'nompi'] 
     - python
     - pybind11 >=2.3.0
-    - adios >=1.13.1                    # [unix and mpi == 'nompi']
-    - hdf5  >=1.8.13                    # [mpi == 'nompi']
+    # need to list hdf5|adios twice to get version pinning from conda_build_config
+    # and build pinning from {{ mpi_prefix }}
+    - adios >=1.13.1                    # [unix]
+    - hdf5  >=1.8.13
     - adios >=1.13.1 = mpi_{{ mpi }}_*  # [unix and mpi != 'nompi']
     - hdf5  >=1.8.13 = mpi_{{ mpi }}_*  # [mpi != 'nompi']
   run:


### PR DESCRIPTION
need to list hdf5 and adios twice to get version pinning from `conda_build_config` and build pinning from `{{ mpi_prefix }}`

See https://github.com/conda-forge/h5py-feedstock/pull/57
Potentially helps with #32

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase @conda-forge-admin, please rerender in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
