### PR TITLE
[WIP] OSX: Enable ADIOS1 with MPICH

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -85,7 +85,8 @@ if [[ ${target_platform} =~ .*aarch64.* ]] && [[ "$mpi" == "openmpi" ]]; then
     # https://github.com/qemu/qemu/blob/586f3dced9f2b354480c140c070a3d02a0c66a1e/linux-user/syscall.c#L2530-L2535
     echo "Skipping OpenMPI runtime tests on QEMU for aarch64 due to lack of support..."
 else
-    CTEST_OUTPUT_ON_FAILURE=1 make ${VERBOSE_CM} test
+    # CTEST_OUTPUT_ON_FAILURE=1 make ${VERBOSE_CM} test
+    ctest -VV --output-on-failure
 fi
 
 make install

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -34,14 +34,6 @@ elif [[ ${CXXFLAGS} == *"-std="* ]]; then
 fi
 
 
-# FIXME: ADIOS1 broken with MPICH
-if [[ ${mpi} == "mpich" && ${target_platform} =~ osx.* ]]; then
-    export USE_ADIOS1=OFF
-else
-    export USE_ADIOS1=ON
-fi
-
-
 # MPI variants
 if [[ ${mpi} == "nompi" ]]; then
     export USE_MPI=OFF
@@ -69,7 +61,7 @@ cmake \
     -DCMAKE_CXX_EXTENSIONS=${CXX_EXTENSIONS}  \
     -DopenPMD_USE_MPI=${USE_MPI}              \
     -DopenPMD_USE_HDF5=ON       \
-    -DopenPMD_USE_ADIOS1=${USE_ADIOS1}        \
+    -DopenPMD_USE_ADIOS1=ON     \
     -DopenPMD_USE_ADIOS2=ON     \
     -DopenPMD_USE_PYTHON=ON     \
     -DopenPMD_USE_INTERNAL_PYBIND11=OFF              \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "openpmd-api" %}
 {% set version = "0.11.1a" %}
-{% set build = 2 %}
+{% set build = 3 %}
 {% set version_fn = version.replace("a", "-alpha") %}
 {% set sha256 = "e5591de6a2a059b72d72c19f0fa4e1dd66af0f04ca94d5ce5c7e5cbf1f5d5324" %}
 
@@ -90,7 +90,7 @@ test:
     - test -f ${PREFIX}/lib/libopenPMD.so                                         # [linux]
     - otool -L ${PREFIX}/lib/libopenPMD.dylib                                     # [osx]
     - if exist %LIBRARY_PREFIX%\bin\openPMD.dll (exit 0) else (exit 1)            # [win]
-    - otool -L ${PREFIX}/lib/libopenPMD.ADIOS1.Serial.dylib                       # [osx and mpi != 'mpich']
+    - otool -L ${PREFIX}/lib/libopenPMD.ADIOS1.Serial.dylib                       # [osx]
     - ldd ${PREFIX}/lib/libopenPMD.ADIOS1.Serial.so                               # [linux]
     - if exist %LIBRARY_PREFIX%\cmake\openPMDConfig.cmake (exit 0) else (exit 1)  # [win]
     - test -f ${PREFIX}/share/xeus-cling/tagfiles/openpmd-api-doxygen-web.tag.xml  # [unix]


### PR DESCRIPTION
Enable the ADIOS1 backend on OSX when built with MPICH.

Follow-up to #28.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
