### PR TITLE
NVCC: Fix Build Issues

### DIFF
--- a/recipe/0002-nvcc-visibility.patch
+++ b/recipe/0002-nvcc-visibility.patch
@@ -1,0 +1,126 @@
+From 244afa5253701ac03ecece854de17eb78d7ba6d2 Mon Sep 17 00:00:00 2001
+From: Axel Huebl <axel.huebl@plasma.ninja>
+Date: Mon, 25 Nov 2019 18:20:45 -0800
+Subject: [PATCH] NVCC: No Visibility Attribute
+
+This project is provides host-side APIs [1]. Some downstream
+projects are unable to split their translation units properly in
+host+device and host-only, and just pass all code through `nvcc`.
+Doing so is not appreciated (by me) but tolerated (by me).
+
+Unfortunately, `nvcc` is a bit behind in supporting visibility
+attributes (Nvidia bug report: 2767443 as of v10.2). Assuming that
+openPMD-api itself is built with a proper host-compiler instead of
+`nvcc`, we can live with defining our `EXPORT` macro to nothing
+during downstream consumption.
+
+This causes a compile error when build with GCC <6 and a warning
+with newer GCC in `include/openPMD/IO/IOTask.hpp` for
+`enum class Operation`.
+
+[1] Note: We might support passing device-side pointers in the
+future, though.
+---
+ CHANGELOG.rst                                            | 3 +++
+ include/openPMD/IO/ADIOS/ADIOS1IOHandler.hpp             | 4 +++-
+ include/openPMD/IO/ADIOS/ADIOS1IOHandlerImpl.hpp         | 4 +++-
+ include/openPMD/IO/ADIOS/ParallelADIOS1IOHandler.hpp     | 4 +++-
+ include/openPMD/IO/ADIOS/ParallelADIOS1IOHandlerImpl.hpp | 4 +++-
+ include/openPMD/IO/IOTask.hpp                            | 4 +++-
+ 6 files changed, 18 insertions(+), 5 deletions(-)
+
+diff --git a/CHANGELOG.rst b/CHANGELOG.rst
+index 5a7cb939..694650bf 100644
+--- a/CHANGELOG.rst
++++ b/CHANGELOG.rst
+@@ -21,6 +21,9 @@ Bug Fixes
+ """""""""
+ 
+ - ADIOS2: fix C++17 build #614
++- nvcc:
++
++  - ignore export of ``enum class Operation`` #617
+ 
+ Other
+ """""
+diff --git a/include/openPMD/IO/ADIOS/ADIOS1IOHandler.hpp b/include/openPMD/IO/ADIOS/ADIOS1IOHandler.hpp
+index 63ab961b..42ff2b25 100644
+--- a/include/openPMD/IO/ADIOS/ADIOS1IOHandler.hpp
++++ b/include/openPMD/IO/ADIOS/ADIOS1IOHandler.hpp
+@@ -30,8 +30,10 @@
+ #   include <queue>
+ #endif
+ 
+-#if _MSC_VER
++#ifdef _MSC_VER
+ #   define EXPORT __declspec( dllexport )
++#elif defined(__NVCC__)
++#   define EXPORT
+ #else
+ #   define EXPORT __attribute__((visibility("default")))
+ #endif
+diff --git a/include/openPMD/IO/ADIOS/ADIOS1IOHandlerImpl.hpp b/include/openPMD/IO/ADIOS/ADIOS1IOHandlerImpl.hpp
+index 46710c67..ee6d151f 100644
+--- a/include/openPMD/IO/ADIOS/ADIOS1IOHandlerImpl.hpp
++++ b/include/openPMD/IO/ADIOS/ADIOS1IOHandlerImpl.hpp
+@@ -36,8 +36,10 @@
+ #   include <unordered_set>
+ #endif
+ 
+-#if _MSC_VER
++#ifdef _MSC_VER
+ #   define EXPORT __declspec( dllexport )
++#elif defined(__NVCC__)
++#   define EXPORT
+ #else
+ #   define EXPORT __attribute__((visibility("default")))
+ #endif
+diff --git a/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandler.hpp b/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandler.hpp
+index 17629a84..65ce4ab2 100644
+--- a/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandler.hpp
++++ b/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandler.hpp
+@@ -30,8 +30,10 @@
+ #   include <queue>
+ #endif
+ 
+-#if _MSC_VER
++#ifdef _MSC_VER
+ #   define EXPORT __declspec( dllexport )
++#elif defined(__NVCC__)
++#   define EXPORT
+ #else
+ #   define EXPORT __attribute__((visibility("default")))
+ #endif
+diff --git a/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandlerImpl.hpp b/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandlerImpl.hpp
+index b153fa78..86b2616e 100644
+--- a/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandlerImpl.hpp
++++ b/include/openPMD/IO/ADIOS/ParallelADIOS1IOHandlerImpl.hpp
+@@ -37,8 +37,10 @@
+ #   include <unordered_set>
+ #endif
+ 
+-#if _MSC_VER
++#ifdef _MSC_VER
+ #   define EXPORT __declspec( dllexport )
++#elif defined(__NVCC__)
++#   define EXPORT
+ #else
+ #   define EXPORT __attribute__((visibility("default")))
+ #endif
+diff --git a/include/openPMD/IO/IOTask.hpp b/include/openPMD/IO/IOTask.hpp
+index 0e2ba0ce..a9cfd690 100644
+--- a/include/openPMD/IO/IOTask.hpp
++++ b/include/openPMD/IO/IOTask.hpp
+@@ -30,8 +30,10 @@
+ #include <string>
+ #include <utility>
+ 
+-#if _MSC_VER
++#ifdef _MSC_VER
+ #   define EXPORT __declspec( dllexport )
++#elif defined(__NVCC__)
++#   define EXPORT
+ #else
+ #   define EXPORT __attribute__((visibility("default")))
+ #endif
+

--- a/recipe/0003-nvcc-cxx14-variant.patch
+++ b/recipe/0003-nvcc-cxx14-variant.patch
@@ -1,0 +1,38 @@
+From 33fe2c98b11f985573a3663e9dc9bff1161d0fcd Mon Sep 17 00:00:00 2001
+From: Axel Huebl <axel.huebl@plasma.ninja>
+Date: Mon, 25 Nov 2019 19:06:25 -0800
+Subject: [PATCH] MPark.Variant: Hotfix NVCC C++14
+
+Apply a hotfix for C++14 builds with NVCC in downstream
+projects.
+---
+ CHANGELOG.rst                                              | 1 +
+ share/openPMD/thirdParty/variant/include/mpark/variant.hpp | 2 +-
+ 2 files changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/CHANGELOG.rst b/CHANGELOG.rst
+index 694650bf..95421994 100644
+--- a/CHANGELOG.rst
++++ b/CHANGELOG.rst
+@@ -24,6 +24,7 @@ Bug Fixes
+ - nvcc:
+ 
+   - ignore export of ``enum class Operation`` #617
++  - fix C++14 build #618
+ 
+ Other
+ """""
+diff --git a/share/openPMD/thirdParty/variant/include/mpark/variant.hpp b/share/openPMD/thirdParty/variant/include/mpark/variant.hpp
+index 990a44cb..4ab6e2fa 100644
+--- a/share/openPMD/thirdParty/variant/include/mpark/variant.hpp
++++ b/share/openPMD/thirdParty/variant/include/mpark/variant.hpp
+@@ -2655,7 +2655,7 @@ namespace mpark {
+     return false;
+   }
+ 
+-#ifdef MPARK_CPP14_CONSTEXPR
++#if defined(MPARK_CPP14_CONSTEXPR) && !defined(__NVCC__)
+   namespace detail {
+ 
+     inline constexpr bool all(std::initializer_list<bool> bs) {
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "openpmd-api" %}
 {% set version = "0.10.0a" %}
-{% set build = 1 %}
+{% set build = 2 %}
 {% set version_fn = version.replace("a", "-alpha") %}
 {% set sha256 = "1a19bba8435bee0a6a898453752a9e2108221b0f1a7137038596a2d4b6b10661" %}
 
@@ -24,6 +24,12 @@ source:
     # ADIOS2 build with C++17
     # https://github.com/openPMD/openPMD-api/pull/614
     - 0001-adios-cxx17.patch
+    # NVCC has no visiblity attribute
+    # https://github.com/openPMD/openPMD-api/pull/617
+    - 0002-nvcc-visibility.patch
+    # NVCC fails to build MPark.Variant in C++14
+    # https://github.com/openPMD/openPMD-api/pull/618
+    - 0003-nvcc-cxx14-variant.patch
 
 build:
   number: {{ build }}


### PR DESCRIPTION
Fix build issues with NVCC lacking visiblity attributes and C++14 builds failing to build MPark.Variant.

Refs.:
- https://github.com/openPMD/openPMD-api/pull/617
- https://github.com/openPMD/openPMD-api/pull/618

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
