### PR TITLE
ppc64le: limit CPU_COUNT

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -80,6 +80,12 @@ cmake \
     ${CMAKE_PLATFORM_FLAGS[@]}        \
     ${SRC_DIR}
 
+# compiler error or resource exhaustion on PPC64le Travis-CI builds with:
+#   powerpc64le-conda_cos7-linux-gnu-c++: fatal error: Killed signal terminated program cc1plus
+#   FIXME: https://github.com/conda-forge/conda-forge-ci-setup-feedstock/pull/68
+if [[ ${target_platform} =~ .*ppc64le.* ]]; then
+  export CPU_COUNT=2
+fi
 make ${VERBOSE_CM} -j${CPU_COUNT}
 
 if [[ ${target_platform} =~ .*aarch64.* ]] && [[ "$mpi" == "openmpi" ]]; then

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "openpmd-api" %}
 {% set version = "0.10.3a" %}
-{% set build = 0 %}
+{% set build = 1 %}
 {% set version_fn = version.replace("a", "-alpha") %}
 {% set sha256 = "4d3677b6e3b674510ec6376978e6fd125ab830c467cf41b982a982e3e242f805" %}
 


### PR DESCRIPTION
Avoid resource exhaustion during build on Travis-CI ppc64le hardware.
For some reason, `CPU_COUNT` on Travis-CI [is unset](https://github.com/conda-forge/conda-forge-ci-setup-feedstock/blob/a1026adb523b6562c16329170e7e304a25ed4033/recipe/run_conda_forge_build_setup_linux).

Upstream fix proposed in: https://github.com/conda-forge/conda-forge-ci-setup-feedstock/pull/68

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
