### PR TITLE
Release: 0.12.0a

### DIFF
--- a/.ci_support/linux_64_mpimpichpython3.6.____73_pypytarget_platformlinux-64.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.6.____73_pypytarget_platformlinux-64.yaml
@@ -16,10 +16,6 @@ cxx_compiler_version:
 - '7'
 docker_image:
 - condaforge/linux-anvil-comp7
-fortran_compiler:
-- gfortran
-fortran_compiler_version:
-- '7'
 mpi:
 - mpich
 pin_run_as_build:

--- a/.ci_support/linux_64_mpimpichpython3.6.____cpythontarget_platformlinux-64.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.6.____cpythontarget_platformlinux-64.yaml
@@ -16,10 +16,6 @@ cxx_compiler_version:
 - '7'
 docker_image:
 - condaforge/linux-anvil-comp7
-fortran_compiler:
-- gfortran
-fortran_compiler_version:
-- '7'
 mpi:
 - mpich
 pin_run_as_build:

--- a/.ci_support/linux_64_mpimpichpython3.7.____cpythontarget_platformlinux-64.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.7.____cpythontarget_platformlinux-64.yaml
@@ -16,10 +16,6 @@ cxx_compiler_version:
 - '7'
 docker_image:
 - condaforge/linux-anvil-comp7
-fortran_compiler:
-- gfortran
-fortran_compiler_version:
-- '7'
 mpi:
 - mpich
 pin_run_as_build:

--- a/.ci_support/linux_64_mpimpichpython3.8.____cpythontarget_platformlinux-64.yaml
+++ b/.ci_support/linux_64_mpimpichpython3.8.____cpythontarget_platformlinux-64.yaml
@@ -16,10 +16,6 @@ cxx_compiler_version:
 - '7'
 docker_image:
 - condaforge/linux-anvil-comp7
-fortran_compiler:
-- gfortran
-fortran_compiler_version:
-- '7'
 mpi:
 - mpich
 pin_run_as_build:

--- a/.ci_support/linux_64_mpinompipython3.6.____73_pypytarget_platformlinux-64.yaml
+++ b/.ci_support/linux_64_mpinompipython3.6.____73_pypytarget_platformlinux-64.yaml
@@ -16,10 +16,6 @@ cxx_compiler_version:
 - '7'
 docker_image:
 - condaforge/linux-anvil-comp7
-fortran_compiler:
-- gfortran
-fortran_compiler_version:
-- '7'
 mpi:
 - nompi
 pin_run_as_build:

--- a/.ci_support/linux_64_mpinompipython3.6.____cpythontarget_platformlinux-64.yaml
+++ b/.ci_support/linux_64_mpinompipython3.6.____cpythontarget_platformlinux-64.yaml
@@ -16,10 +16,6 @@ cxx_compiler_version:
 - '7'
 docker_image:
 - condaforge/linux-anvil-comp7
-fortran_compiler:
-- gfortran
-fortran_compiler_version:
-- '7'
 mpi:
 - nompi
 pin_run_as_build:

--- a/.ci_support/linux_64_mpinompipython3.7.____cpythontarget_platformlinux-64.yaml
+++ b/.ci_support/linux_64_mpinompipython3.7.____cpythontarget_platformlinux-64.yaml
@@ -16,10 +16,6 @@ cxx_compiler_version:
 - '7'
 docker_image:
 - condaforge/linux-anvil-comp7
-fortran_compiler:
-- gfortran
-fortran_compiler_version:
-- '7'
 mpi:
 - nompi
 pin_run_as_build:

--- a/.ci_support/linux_64_mpinompipython3.8.____cpythontarget_platformlinux-64.yaml
+++ b/.ci_support/linux_64_mpinompipython3.8.____cpythontarget_platformlinux-64.yaml
@@ -16,10 +16,6 @@ cxx_compiler_version:
 - '7'
 docker_image:
 - condaforge/linux-anvil-comp7
-fortran_compiler:
-- gfortran
-fortran_compiler_version:
-- '7'
 mpi:
 - nompi
 pin_run_as_build:

--- a/.ci_support/linux_64_mpiopenmpipython3.6.____73_pypytarget_platformlinux-64.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.6.____73_pypytarget_platformlinux-64.yaml
@@ -16,10 +16,6 @@ cxx_compiler_version:
 - '7'
 docker_image:
 - condaforge/linux-anvil-comp7
-fortran_compiler:
-- gfortran
-fortran_compiler_version:
-- '7'
 mpi:
 - openmpi
 pin_run_as_build:

--- a/.ci_support/linux_64_mpiopenmpipython3.6.____cpythontarget_platformlinux-64.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.6.____cpythontarget_platformlinux-64.yaml
@@ -16,10 +16,6 @@ cxx_compiler_version:
 - '7'
 docker_image:
 - condaforge/linux-anvil-comp7
-fortran_compiler:
-- gfortran
-fortran_compiler_version:
-- '7'
 mpi:
 - openmpi
 pin_run_as_build:

--- a/.ci_support/linux_64_mpiopenmpipython3.7.____cpythontarget_platformlinux-64.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.7.____cpythontarget_platformlinux-64.yaml
@@ -16,10 +16,6 @@ cxx_compiler_version:
 - '7'
 docker_image:
 - condaforge/linux-anvil-comp7
-fortran_compiler:
-- gfortran
-fortran_compiler_version:
-- '7'
 mpi:
 - openmpi
 pin_run_as_build:

--- a/.ci_support/linux_64_mpiopenmpipython3.8.____cpythontarget_platformlinux-64.yaml
+++ b/.ci_support/linux_64_mpiopenmpipython3.8.____cpythontarget_platformlinux-64.yaml
@@ -16,10 +16,6 @@ cxx_compiler_version:
 - '7'
 docker_image:
 - condaforge/linux-anvil-comp7
-fortran_compiler:
-- gfortran
-fortran_compiler_version:
-- '7'
 mpi:
 - openmpi
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_mpimpichpython3.6.____73_pypytarget_platformlinux-aarch64.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.6.____73_pypytarget_platformlinux-aarch64.yaml
@@ -5,7 +5,7 @@ VERBOSE_CM:
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '7.5'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -19,13 +19,9 @@ curl:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7'
+- '7.5'
 docker_image:
 - condaforge/linux-anvil-aarch64
-fortran_compiler:
-- gfortran
-fortran_compiler_version:
-- '7'
 mpi:
 - mpich
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_mpimpichpython3.6.____cpythontarget_platformlinux-aarch64.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.6.____cpythontarget_platformlinux-aarch64.yaml
@@ -5,7 +5,7 @@ VERBOSE_CM:
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '7.5'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -19,13 +19,9 @@ curl:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7'
+- '7.5'
 docker_image:
 - condaforge/linux-anvil-aarch64
-fortran_compiler:
-- gfortran
-fortran_compiler_version:
-- '7'
 mpi:
 - mpich
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_mpimpichpython3.7.____cpythontarget_platformlinux-aarch64.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.7.____cpythontarget_platformlinux-aarch64.yaml
@@ -5,7 +5,7 @@ VERBOSE_CM:
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '7.5'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -19,13 +19,9 @@ curl:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7'
+- '7.5'
 docker_image:
 - condaforge/linux-anvil-aarch64
-fortran_compiler:
-- gfortran
-fortran_compiler_version:
-- '7'
 mpi:
 - mpich
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_mpimpichpython3.8.____cpythontarget_platformlinux-aarch64.yaml
+++ b/.ci_support/linux_aarch64_mpimpichpython3.8.____cpythontarget_platformlinux-aarch64.yaml
@@ -5,7 +5,7 @@ VERBOSE_CM:
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '7.5'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -19,13 +19,9 @@ curl:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7'
+- '7.5'
 docker_image:
 - condaforge/linux-anvil-aarch64
-fortran_compiler:
-- gfortran
-fortran_compiler_version:
-- '7'
 mpi:
 - mpich
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_mpinompipython3.6.____73_pypytarget_platformlinux-aarch64.yaml
+++ b/.ci_support/linux_aarch64_mpinompipython3.6.____73_pypytarget_platformlinux-aarch64.yaml
@@ -5,7 +5,7 @@ VERBOSE_CM:
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '7.5'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -19,13 +19,9 @@ curl:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7'
+- '7.5'
 docker_image:
 - condaforge/linux-anvil-aarch64
-fortran_compiler:
-- gfortran
-fortran_compiler_version:
-- '7'
 mpi:
 - nompi
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_mpinompipython3.6.____cpythontarget_platformlinux-aarch64.yaml
+++ b/.ci_support/linux_aarch64_mpinompipython3.6.____cpythontarget_platformlinux-aarch64.yaml
@@ -5,7 +5,7 @@ VERBOSE_CM:
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '7.5'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -19,13 +19,9 @@ curl:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7'
+- '7.5'
 docker_image:
 - condaforge/linux-anvil-aarch64
-fortran_compiler:
-- gfortran
-fortran_compiler_version:
-- '7'
 mpi:
 - nompi
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_mpinompipython3.7.____cpythontarget_platformlinux-aarch64.yaml
+++ b/.ci_support/linux_aarch64_mpinompipython3.7.____cpythontarget_platformlinux-aarch64.yaml
@@ -5,7 +5,7 @@ VERBOSE_CM:
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '7.5'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -19,13 +19,9 @@ curl:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7'
+- '7.5'
 docker_image:
 - condaforge/linux-anvil-aarch64
-fortran_compiler:
-- gfortran
-fortran_compiler_version:
-- '7'
 mpi:
 - nompi
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_mpinompipython3.8.____cpythontarget_platformlinux-aarch64.yaml
+++ b/.ci_support/linux_aarch64_mpinompipython3.8.____cpythontarget_platformlinux-aarch64.yaml
@@ -5,7 +5,7 @@ VERBOSE_CM:
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '7.5'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -19,13 +19,9 @@ curl:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7'
+- '7.5'
 docker_image:
 - condaforge/linux-anvil-aarch64
-fortran_compiler:
-- gfortran
-fortran_compiler_version:
-- '7'
 mpi:
 - nompi
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.6.____73_pypytarget_platformlinux-aarch64.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.6.____73_pypytarget_platformlinux-aarch64.yaml
@@ -5,7 +5,7 @@ VERBOSE_CM:
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '7.5'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -19,13 +19,9 @@ curl:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7'
+- '7.5'
 docker_image:
 - condaforge/linux-anvil-aarch64
-fortran_compiler:
-- gfortran
-fortran_compiler_version:
-- '7'
 mpi:
 - openmpi
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.6.____cpythontarget_platformlinux-aarch64.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.6.____cpythontarget_platformlinux-aarch64.yaml
@@ -5,7 +5,7 @@ VERBOSE_CM:
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '7.5'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -19,13 +19,9 @@ curl:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7'
+- '7.5'
 docker_image:
 - condaforge/linux-anvil-aarch64
-fortran_compiler:
-- gfortran
-fortran_compiler_version:
-- '7'
 mpi:
 - openmpi
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.7.____cpythontarget_platformlinux-aarch64.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.7.____cpythontarget_platformlinux-aarch64.yaml
@@ -5,7 +5,7 @@ VERBOSE_CM:
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '7.5'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -19,13 +19,9 @@ curl:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7'
+- '7.5'
 docker_image:
 - condaforge/linux-anvil-aarch64
-fortran_compiler:
-- gfortran
-fortran_compiler_version:
-- '7'
 mpi:
 - openmpi
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_mpiopenmpipython3.8.____cpythontarget_platformlinux-aarch64.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpipython3.8.____cpythontarget_platformlinux-aarch64.yaml
@@ -5,7 +5,7 @@ VERBOSE_CM:
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '7.5'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -19,13 +19,9 @@ curl:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7'
+- '7.5'
 docker_image:
 - condaforge/linux-anvil-aarch64
-fortran_compiler:
-- gfortran
-fortran_compiler_version:
-- '7'
 mpi:
 - openmpi
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_mpimpichpython3.6.____73_pypytarget_platformlinux-ppc64le.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.6.____73_pypytarget_platformlinux-ppc64le.yaml
@@ -16,10 +16,6 @@ cxx_compiler_version:
 - '8'
 docker_image:
 - condaforge/linux-anvil-ppc64le
-fortran_compiler:
-- gfortran
-fortran_compiler_version:
-- '8'
 mpi:
 - mpich
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_mpimpichpython3.6.____cpythontarget_platformlinux-ppc64le.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.6.____cpythontarget_platformlinux-ppc64le.yaml
@@ -16,10 +16,6 @@ cxx_compiler_version:
 - '8'
 docker_image:
 - condaforge/linux-anvil-ppc64le
-fortran_compiler:
-- gfortran
-fortran_compiler_version:
-- '8'
 mpi:
 - mpich
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_mpimpichpython3.7.____cpythontarget_platformlinux-ppc64le.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.7.____cpythontarget_platformlinux-ppc64le.yaml
@@ -16,10 +16,6 @@ cxx_compiler_version:
 - '8'
 docker_image:
 - condaforge/linux-anvil-ppc64le
-fortran_compiler:
-- gfortran
-fortran_compiler_version:
-- '8'
 mpi:
 - mpich
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_mpimpichpython3.8.____cpythontarget_platformlinux-ppc64le.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichpython3.8.____cpythontarget_platformlinux-ppc64le.yaml
@@ -16,10 +16,6 @@ cxx_compiler_version:
 - '8'
 docker_image:
 - condaforge/linux-anvil-ppc64le
-fortran_compiler:
-- gfortran
-fortran_compiler_version:
-- '8'
 mpi:
 - mpich
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_mpinompipython3.6.____73_pypytarget_platformlinux-ppc64le.yaml
+++ b/.ci_support/linux_ppc64le_mpinompipython3.6.____73_pypytarget_platformlinux-ppc64le.yaml
@@ -16,10 +16,6 @@ cxx_compiler_version:
 - '8'
 docker_image:
 - condaforge/linux-anvil-ppc64le
-fortran_compiler:
-- gfortran
-fortran_compiler_version:
-- '8'
 mpi:
 - nompi
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_mpinompipython3.6.____cpythontarget_platformlinux-ppc64le.yaml
+++ b/.ci_support/linux_ppc64le_mpinompipython3.6.____cpythontarget_platformlinux-ppc64le.yaml
@@ -16,10 +16,6 @@ cxx_compiler_version:
 - '8'
 docker_image:
 - condaforge/linux-anvil-ppc64le
-fortran_compiler:
-- gfortran
-fortran_compiler_version:
-- '8'
 mpi:
 - nompi
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_mpinompipython3.7.____cpythontarget_platformlinux-ppc64le.yaml
+++ b/.ci_support/linux_ppc64le_mpinompipython3.7.____cpythontarget_platformlinux-ppc64le.yaml
@@ -16,10 +16,6 @@ cxx_compiler_version:
 - '8'
 docker_image:
 - condaforge/linux-anvil-ppc64le
-fortran_compiler:
-- gfortran
-fortran_compiler_version:
-- '8'
 mpi:
 - nompi
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_mpinompipython3.8.____cpythontarget_platformlinux-ppc64le.yaml
+++ b/.ci_support/linux_ppc64le_mpinompipython3.8.____cpythontarget_platformlinux-ppc64le.yaml
@@ -16,10 +16,6 @@ cxx_compiler_version:
 - '8'
 docker_image:
 - condaforge/linux-anvil-ppc64le
-fortran_compiler:
-- gfortran
-fortran_compiler_version:
-- '8'
 mpi:
 - nompi
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.6.____73_pypytarget_platformlinux-ppc64le.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.6.____73_pypytarget_platformlinux-ppc64le.yaml
@@ -16,10 +16,6 @@ cxx_compiler_version:
 - '8'
 docker_image:
 - condaforge/linux-anvil-ppc64le
-fortran_compiler:
-- gfortran
-fortran_compiler_version:
-- '8'
 mpi:
 - openmpi
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.6.____cpythontarget_platformlinux-ppc64le.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.6.____cpythontarget_platformlinux-ppc64le.yaml
@@ -16,10 +16,6 @@ cxx_compiler_version:
 - '8'
 docker_image:
 - condaforge/linux-anvil-ppc64le
-fortran_compiler:
-- gfortran
-fortran_compiler_version:
-- '8'
 mpi:
 - openmpi
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.7.____cpythontarget_platformlinux-ppc64le.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.7.____cpythontarget_platformlinux-ppc64le.yaml
@@ -16,10 +16,6 @@ cxx_compiler_version:
 - '8'
 docker_image:
 - condaforge/linux-anvil-ppc64le
-fortran_compiler:
-- gfortran
-fortran_compiler_version:
-- '8'
 mpi:
 - openmpi
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_mpiopenmpipython3.8.____cpythontarget_platformlinux-ppc64le.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpipython3.8.____cpythontarget_platformlinux-ppc64le.yaml
@@ -16,10 +16,6 @@ cxx_compiler_version:
 - '8'
 docker_image:
 - condaforge/linux-anvil-ppc64le
-fortran_compiler:
-- gfortran
-fortran_compiler_version:
-- '8'
 mpi:
 - openmpi
 pin_run_as_build:

--- a/.ci_support/osx_64_mpimpichpython3.6.____73_pypytarget_platformosx-64.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.6.____73_pypytarget_platformosx-64.yaml
@@ -18,8 +18,6 @@ cxx_compiler_version:
 - '10'
 macos_machine:
 - x86_64-apple-darwin13.4.0
-macos_min_version:
-- '10.9'
 mpi:
 - mpich
 pin_run_as_build:

--- a/.ci_support/osx_64_mpimpichpython3.6.____cpythontarget_platformosx-64.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.6.____cpythontarget_platformosx-64.yaml
@@ -18,8 +18,6 @@ cxx_compiler_version:
 - '10'
 macos_machine:
 - x86_64-apple-darwin13.4.0
-macos_min_version:
-- '10.9'
 mpi:
 - mpich
 pin_run_as_build:

--- a/.ci_support/osx_64_mpimpichpython3.7.____cpythontarget_platformosx-64.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.7.____cpythontarget_platformosx-64.yaml
@@ -18,8 +18,6 @@ cxx_compiler_version:
 - '10'
 macos_machine:
 - x86_64-apple-darwin13.4.0
-macos_min_version:
-- '10.9'
 mpi:
 - mpich
 pin_run_as_build:

--- a/.ci_support/osx_64_mpimpichpython3.8.____cpythontarget_platformosx-64.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.8.____cpythontarget_platformosx-64.yaml
@@ -18,8 +18,6 @@ cxx_compiler_version:
 - '10'
 macos_machine:
 - x86_64-apple-darwin13.4.0
-macos_min_version:
-- '10.9'
 mpi:
 - mpich
 pin_run_as_build:

--- a/.ci_support/osx_64_mpinompipython3.6.____73_pypytarget_platformosx-64.yaml
+++ b/.ci_support/osx_64_mpinompipython3.6.____73_pypytarget_platformosx-64.yaml
@@ -18,8 +18,6 @@ cxx_compiler_version:
 - '10'
 macos_machine:
 - x86_64-apple-darwin13.4.0
-macos_min_version:
-- '10.9'
 mpi:
 - nompi
 pin_run_as_build:

--- a/.ci_support/osx_64_mpinompipython3.6.____cpythontarget_platformosx-64.yaml
+++ b/.ci_support/osx_64_mpinompipython3.6.____cpythontarget_platformosx-64.yaml
@@ -18,8 +18,6 @@ cxx_compiler_version:
 - '10'
 macos_machine:
 - x86_64-apple-darwin13.4.0
-macos_min_version:
-- '10.9'
 mpi:
 - nompi
 pin_run_as_build:

--- a/.ci_support/osx_64_mpinompipython3.7.____cpythontarget_platformosx-64.yaml
+++ b/.ci_support/osx_64_mpinompipython3.7.____cpythontarget_platformosx-64.yaml
@@ -18,8 +18,6 @@ cxx_compiler_version:
 - '10'
 macos_machine:
 - x86_64-apple-darwin13.4.0
-macos_min_version:
-- '10.9'
 mpi:
 - nompi
 pin_run_as_build:

--- a/.ci_support/osx_64_mpinompipython3.8.____cpythontarget_platformosx-64.yaml
+++ b/.ci_support/osx_64_mpinompipython3.8.____cpythontarget_platformosx-64.yaml
@@ -18,8 +18,6 @@ cxx_compiler_version:
 - '10'
 macos_machine:
 - x86_64-apple-darwin13.4.0
-macos_min_version:
-- '10.9'
 mpi:
 - nompi
 pin_run_as_build:

--- a/.ci_support/osx_64_mpiopenmpipython3.6.____73_pypytarget_platformosx-64.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.6.____73_pypytarget_platformosx-64.yaml
@@ -18,8 +18,6 @@ cxx_compiler_version:
 - '10'
 macos_machine:
 - x86_64-apple-darwin13.4.0
-macos_min_version:
-- '10.9'
 mpi:
 - openmpi
 pin_run_as_build:

--- a/.ci_support/osx_64_mpiopenmpipython3.6.____cpythontarget_platformosx-64.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.6.____cpythontarget_platformosx-64.yaml
@@ -18,8 +18,6 @@ cxx_compiler_version:
 - '10'
 macos_machine:
 - x86_64-apple-darwin13.4.0
-macos_min_version:
-- '10.9'
 mpi:
 - openmpi
 pin_run_as_build:

--- a/.ci_support/osx_64_mpiopenmpipython3.7.____cpythontarget_platformosx-64.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.7.____cpythontarget_platformosx-64.yaml
@@ -18,8 +18,6 @@ cxx_compiler_version:
 - '10'
 macos_machine:
 - x86_64-apple-darwin13.4.0
-macos_min_version:
-- '10.9'
 mpi:
 - openmpi
 pin_run_as_build:

--- a/.ci_support/osx_64_mpiopenmpipython3.8.____cpythontarget_platformosx-64.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.8.____cpythontarget_platformosx-64.yaml
@@ -18,8 +18,6 @@ cxx_compiler_version:
 - '10'
 macos_machine:
 - x86_64-apple-darwin13.4.0
-macos_min_version:
-- '10.9'
 mpi:
 - openmpi
 pin_run_as_build:

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @C0nsultant @ax3l
+* @ax3l @franzpoeschel

--- a/README.md
+++ b/README.md
@@ -505,6 +505,6 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
-* [@C0nsultant](https://github.com/C0nsultant/)
 * [@ax3l](https://github.com/ax3l/)
+* [@franzpoeschel](https://github.com/franzpoeschel/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,8 @@
 {% set name = "openpmd-api" %}
-{% set version = "0.11.1a" %}
-{% set build = 3 %}
+{% set version = "0.12.0a" %}
+{% set build = 1 %}
 {% set version_fn = version.replace("a", "-alpha") %}
-{% set sha256 = "e5591de6a2a059b72d72c19f0fa4e1dd66af0f04ca94d5ce5c7e5cbf1f5d5324" %}
+{% set sha256 = "2529e0df68b2f7606c53439d42e5444ed4c2acf61bb1779ffd07b95d10b234ff" %}
 
 # ensure mpi is defined (needed for conda-smithy recipe-lint)
 {% set mpi = mpi or 'nompi' %}
@@ -52,8 +52,6 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    # FIXME: pulled in by ADIOS2, see https://github.com/ornladios/ADIOS2/issues/1885
-    - {{ compiler('fortran') }}  # [linux]
     - make  # [unix]
     - cmake >=3.11
     - curl
@@ -65,10 +63,10 @@ requirements:
     # need to list hdf5|adios|adios2 twice to get version pinning from
     # conda_build_config and build pinning from {{ mpi_prefix }}
     - adios  >=1.13.1                    # [unix]
-    - adios2 >=2.4.0
+    - adios2 >=2.6.0
     - hdf5   >=1.8.13
     - adios  >=1.13.1 = mpi_{{ mpi }}_*  # [unix and mpi != 'nompi']
-    - adios2 >=2.4.0  = mpi_{{ mpi }}_*  # [mpi != 'nompi']
+    - adios2 >=2.6.0  = mpi_{{ mpi }}_*  # [mpi != 'nompi']
     - hdf5   >=1.8.13 = mpi_{{ mpi }}_*  # [mpi != 'nompi']
   run:
     - {{ mpi }}  # [mpi != 'nompi']
@@ -118,4 +116,4 @@ about:
 extra:
   recipe-maintainers:
     - ax3l
-    - C0nsultant
+    - franzpoeschel


### PR DESCRIPTION
This release adds data type support for complex numbers, allows to close iterations and adds first support for backend configuration options (via JSON), which are currently implemented for ADIOS2. Further installation options have been added (homebrew and CLI tool support with pip). New free standing functions and macro defines are provided for version checks.

Add @franzpoeschel as co-maintainer to reduce our [bus-factor](https://en.wikipedia.org/wiki/Bus_factor).

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
