### PR TITLE
Fix: ADIOS2==2.7.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "openpmd-api" %}
 {% set version = "0.14.5" %}
-{% set build = 0 %}
+{% set build = 1 %}
 {% set sha256 = "e3f509098e75014394877e0dc91f833e57ced5552b110c7339a69e9dbe49bf62" %}
 
 # ensure mpi is defined (needed for conda-smithy recipe-lint)
@@ -74,11 +74,11 @@ requirements:
     # need to list hdf5|adios|adios2 twice to get version pinning from
     # conda_build_config and build pinning from {{ mpi_prefix }}
     - adios  >=1.13.1                    # [unix]
-    - adios2 >=2.7.0                     # [python_impl != 'pypy']
+    - adios2 ==2.7.1                     # [python_impl != 'pypy']
     - catch2 >=2.13.4,<3
     - hdf5   >=1.8.13
     - adios  >=1.13.1 = mpi_{{ mpi }}_*  # [unix and mpi != 'nompi']
-    - adios2 >=2.7.0  = mpi_{{ mpi }}_*  # [mpi != 'nompi' and python_impl != 'pypy']
+    - adios2 ==2.7.1  = mpi_{{ mpi }}_*  # [mpi != 'nompi' and python_impl != 'pypy']
     - hdf5   >=1.8.13 = mpi_{{ mpi }}_*  # [mpi != 'nompi']
   run:
     - {{ mpi }}  # [mpi != 'nompi']


### PR DESCRIPTION
ADIOS2 v2.8 introduced breaking operator (compression) changes, which causes issues reading older files.

This resets the update to newes (2.8.0) that came in via #88 for our 0.14.5 release.

* https://github.com/openPMD/openPMD-api/issues/1293
* https://github.com/ornladios/ADIOS2/issues/3273

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
