### PR TITLE
Fix: no run_exports for ADIOS2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "openpmd-api" %}
 {% set version = "0.15.1" %}
-{% set build = 2 %}
+{% set build = 3 %}
 {% set sha256 = "0e81652152391ba4d2b62cfac95238b11233a4f89ff45e1fcffcc7bcd79dabe1" %}
 
 # ensure mpi is defined (needed for conda-smithy recipe-lint)
@@ -46,9 +46,7 @@ build:
     - {{ name }} * {{ mpi_prefix }}_*
     # patch-releases are not (yet) ABI compatible:
     #   https://docs.conda.io/projects/conda-build/en/latest/resources/variants.html#referencing-subpackages
-    #   https://abi-laboratory.pro/?view=timeline&l=adios2
     #   https://abi-laboratory.pro/?view=timeline&l=openpmd-api
-    - {{ pin_compatible('adios2', min_pin='x.x.x', max_pin='x.x.x') }}  # [python_impl != 'pypy']
     - openpmd-api {{ version }}
 
 requirements:


### PR DESCRIPTION
Cannot recall why
  https://github.com/conda-forge/staged-recipes/pull/22171#issuecomment-1574574075

but fixed now.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
