### PR TITLE
rebuild for hdf5 1.14.1

### DIFF
--- a/.ci_support/linux_64_mpimpichnumpy1.21python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_mpimpichnumpy1.21python3.10.____cpythonpython_implcpython.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - mpich
 mpich:

--- a/.ci_support/linux_64_mpimpichnumpy1.21python3.8.____73_pypypython_implpypy.yaml
+++ b/.ci_support/linux_64_mpimpichnumpy1.21python3.8.____73_pypypython_implpypy.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - mpich
 mpich:

--- a/.ci_support/linux_64_mpimpichnumpy1.21python3.8.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_mpimpichnumpy1.21python3.8.____cpythonpython_implcpython.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - mpich
 mpich:

--- a/.ci_support/linux_64_mpimpichnumpy1.21python3.9.____73_pypypython_implpypy.yaml
+++ b/.ci_support/linux_64_mpimpichnumpy1.21python3.9.____73_pypypython_implpypy.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - mpich
 mpich:

--- a/.ci_support/linux_64_mpimpichnumpy1.21python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_mpimpichnumpy1.21python3.9.____cpythonpython_implcpython.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - mpich
 mpich:

--- a/.ci_support/linux_64_mpimpichnumpy1.23python3.11.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_mpimpichnumpy1.23python3.11.____cpythonpython_implcpython.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - mpich
 mpich:

--- a/.ci_support/linux_64_mpinompinumpy1.21python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_mpinompinumpy1.21python3.10.____cpythonpython_implcpython.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - nompi
 mpich:

--- a/.ci_support/linux_64_mpinompinumpy1.21python3.8.____73_pypypython_implpypy.yaml
+++ b/.ci_support/linux_64_mpinompinumpy1.21python3.8.____73_pypypython_implpypy.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - nompi
 mpich:

--- a/.ci_support/linux_64_mpinompinumpy1.21python3.8.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_mpinompinumpy1.21python3.8.____cpythonpython_implcpython.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - nompi
 mpich:

--- a/.ci_support/linux_64_mpinompinumpy1.21python3.9.____73_pypypython_implpypy.yaml
+++ b/.ci_support/linux_64_mpinompinumpy1.21python3.9.____73_pypypython_implpypy.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - nompi
 mpich:

--- a/.ci_support/linux_64_mpinompinumpy1.21python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_mpinompinumpy1.21python3.9.____cpythonpython_implcpython.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - nompi
 mpich:

--- a/.ci_support/linux_64_mpinompinumpy1.23python3.11.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_mpinompinumpy1.23python3.11.____cpythonpython_implcpython.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - nompi
 mpich:

--- a/.ci_support/linux_64_mpiopenmpinumpy1.21python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_mpiopenmpinumpy1.21python3.10.____cpythonpython_implcpython.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - openmpi
 mpich:

--- a/.ci_support/linux_64_mpiopenmpinumpy1.21python3.8.____73_pypypython_implpypy.yaml
+++ b/.ci_support/linux_64_mpiopenmpinumpy1.21python3.8.____73_pypypython_implpypy.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - openmpi
 mpich:

--- a/.ci_support/linux_64_mpiopenmpinumpy1.21python3.8.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_mpiopenmpinumpy1.21python3.8.____cpythonpython_implcpython.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - openmpi
 mpich:

--- a/.ci_support/linux_64_mpiopenmpinumpy1.21python3.9.____73_pypypython_implpypy.yaml
+++ b/.ci_support/linux_64_mpiopenmpinumpy1.21python3.9.____73_pypypython_implpypy.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - openmpi
 mpich:

--- a/.ci_support/linux_64_mpiopenmpinumpy1.21python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_mpiopenmpinumpy1.21python3.9.____cpythonpython_implcpython.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - openmpi
 mpich:

--- a/.ci_support/linux_64_mpiopenmpinumpy1.23python3.11.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_mpiopenmpinumpy1.23python3.11.____cpythonpython_implcpython.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - openmpi
 mpich:

--- a/.ci_support/linux_aarch64_mpimpichnumpy1.21python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_aarch64_mpimpichnumpy1.21python3.10.____cpythonpython_implcpython.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - mpich
 mpich:

--- a/.ci_support/linux_aarch64_mpimpichnumpy1.21python3.8.____73_pypypython_implpypy.yaml
+++ b/.ci_support/linux_aarch64_mpimpichnumpy1.21python3.8.____73_pypypython_implpypy.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - mpich
 mpich:

--- a/.ci_support/linux_aarch64_mpimpichnumpy1.21python3.8.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_aarch64_mpimpichnumpy1.21python3.8.____cpythonpython_implcpython.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - mpich
 mpich:

--- a/.ci_support/linux_aarch64_mpimpichnumpy1.21python3.9.____73_pypypython_implpypy.yaml
+++ b/.ci_support/linux_aarch64_mpimpichnumpy1.21python3.9.____73_pypypython_implpypy.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - mpich
 mpich:

--- a/.ci_support/linux_aarch64_mpimpichnumpy1.21python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_aarch64_mpimpichnumpy1.21python3.9.____cpythonpython_implcpython.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - mpich
 mpich:

--- a/.ci_support/linux_aarch64_mpimpichnumpy1.23python3.11.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_aarch64_mpimpichnumpy1.23python3.11.____cpythonpython_implcpython.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - mpich
 mpich:

--- a/.ci_support/linux_aarch64_mpinompinumpy1.21python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_aarch64_mpinompinumpy1.21python3.10.____cpythonpython_implcpython.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - nompi
 mpich:

--- a/.ci_support/linux_aarch64_mpinompinumpy1.21python3.8.____73_pypypython_implpypy.yaml
+++ b/.ci_support/linux_aarch64_mpinompinumpy1.21python3.8.____73_pypypython_implpypy.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - nompi
 mpich:

--- a/.ci_support/linux_aarch64_mpinompinumpy1.21python3.8.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_aarch64_mpinompinumpy1.21python3.8.____cpythonpython_implcpython.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - nompi
 mpich:

--- a/.ci_support/linux_aarch64_mpinompinumpy1.21python3.9.____73_pypypython_implpypy.yaml
+++ b/.ci_support/linux_aarch64_mpinompinumpy1.21python3.9.____73_pypypython_implpypy.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - nompi
 mpich:

--- a/.ci_support/linux_aarch64_mpinompinumpy1.21python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_aarch64_mpinompinumpy1.21python3.9.____cpythonpython_implcpython.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - nompi
 mpich:

--- a/.ci_support/linux_aarch64_mpinompinumpy1.23python3.11.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_aarch64_mpinompinumpy1.23python3.11.____cpythonpython_implcpython.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - nompi
 mpich:

--- a/.ci_support/linux_aarch64_mpiopenmpinumpy1.21python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpinumpy1.21python3.10.____cpythonpython_implcpython.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - openmpi
 mpich:

--- a/.ci_support/linux_aarch64_mpiopenmpinumpy1.21python3.8.____73_pypypython_implpypy.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpinumpy1.21python3.8.____73_pypypython_implpypy.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - openmpi
 mpich:

--- a/.ci_support/linux_aarch64_mpiopenmpinumpy1.21python3.8.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpinumpy1.21python3.8.____cpythonpython_implcpython.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - openmpi
 mpich:

--- a/.ci_support/linux_aarch64_mpiopenmpinumpy1.21python3.9.____73_pypypython_implpypy.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpinumpy1.21python3.9.____73_pypypython_implpypy.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - openmpi
 mpich:

--- a/.ci_support/linux_aarch64_mpiopenmpinumpy1.21python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpinumpy1.21python3.9.____cpythonpython_implcpython.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - openmpi
 mpich:

--- a/.ci_support/linux_aarch64_mpiopenmpinumpy1.23python3.11.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpinumpy1.23python3.11.____cpythonpython_implcpython.yaml
@@ -25,7 +25,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - openmpi
 mpich:

--- a/.ci_support/linux_ppc64le_mpimpichnumpy1.21python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichnumpy1.21python3.10.____cpythonpython_implcpython.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - mpich
 mpich:

--- a/.ci_support/linux_ppc64le_mpimpichnumpy1.21python3.8.____73_pypypython_implpypy.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichnumpy1.21python3.8.____73_pypypython_implpypy.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - mpich
 mpich:

--- a/.ci_support/linux_ppc64le_mpimpichnumpy1.21python3.8.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichnumpy1.21python3.8.____cpythonpython_implcpython.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - mpich
 mpich:

--- a/.ci_support/linux_ppc64le_mpimpichnumpy1.21python3.9.____73_pypypython_implpypy.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichnumpy1.21python3.9.____73_pypypython_implpypy.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - mpich
 mpich:

--- a/.ci_support/linux_ppc64le_mpimpichnumpy1.21python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichnumpy1.21python3.9.____cpythonpython_implcpython.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - mpich
 mpich:

--- a/.ci_support/linux_ppc64le_mpimpichnumpy1.23python3.11.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_ppc64le_mpimpichnumpy1.23python3.11.____cpythonpython_implcpython.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - mpich
 mpich:

--- a/.ci_support/linux_ppc64le_mpinompinumpy1.21python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_ppc64le_mpinompinumpy1.21python3.10.____cpythonpython_implcpython.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - nompi
 mpich:

--- a/.ci_support/linux_ppc64le_mpinompinumpy1.21python3.8.____73_pypypython_implpypy.yaml
+++ b/.ci_support/linux_ppc64le_mpinompinumpy1.21python3.8.____73_pypypython_implpypy.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - nompi
 mpich:

--- a/.ci_support/linux_ppc64le_mpinompinumpy1.21python3.8.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_ppc64le_mpinompinumpy1.21python3.8.____cpythonpython_implcpython.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - nompi
 mpich:

--- a/.ci_support/linux_ppc64le_mpinompinumpy1.21python3.9.____73_pypypython_implpypy.yaml
+++ b/.ci_support/linux_ppc64le_mpinompinumpy1.21python3.9.____73_pypypython_implpypy.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - nompi
 mpich:

--- a/.ci_support/linux_ppc64le_mpinompinumpy1.21python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_ppc64le_mpinompinumpy1.21python3.9.____cpythonpython_implcpython.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - nompi
 mpich:

--- a/.ci_support/linux_ppc64le_mpinompinumpy1.23python3.11.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_ppc64le_mpinompinumpy1.23python3.11.____cpythonpython_implcpython.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - nompi
 mpich:

--- a/.ci_support/linux_ppc64le_mpiopenmpinumpy1.21python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpinumpy1.21python3.10.____cpythonpython_implcpython.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - openmpi
 mpich:

--- a/.ci_support/linux_ppc64le_mpiopenmpinumpy1.21python3.8.____73_pypypython_implpypy.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpinumpy1.21python3.8.____73_pypypython_implpypy.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - openmpi
 mpich:

--- a/.ci_support/linux_ppc64le_mpiopenmpinumpy1.21python3.8.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpinumpy1.21python3.8.____cpythonpython_implcpython.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - openmpi
 mpich:

--- a/.ci_support/linux_ppc64le_mpiopenmpinumpy1.21python3.9.____73_pypypython_implpypy.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpinumpy1.21python3.9.____73_pypypython_implpypy.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - openmpi
 mpich:

--- a/.ci_support/linux_ppc64le_mpiopenmpinumpy1.21python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpinumpy1.21python3.9.____cpythonpython_implcpython.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - openmpi
 mpich:

--- a/.ci_support/linux_ppc64le_mpiopenmpinumpy1.23python3.11.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpinumpy1.23python3.11.____cpythonpython_implcpython.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - openmpi
 mpich:

--- a/.ci_support/migrations/hdf51141.yaml
+++ b/.ci_support/migrations/hdf51141.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+hdf5:
+- 1.14.1
+migrator_ts: 1687165815.3104627

--- a/.ci_support/osx_64_mpimpichnumpy1.21python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy1.21python3.10.____cpythonpython_implcpython.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '15'
 hdf5:
-- 1.12.2
+- 1.14.1
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_mpimpichnumpy1.21python3.8.____73_pypypython_implpypy.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy1.21python3.8.____73_pypypython_implpypy.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '15'
 hdf5:
-- 1.12.2
+- 1.14.1
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_mpimpichnumpy1.21python3.8.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy1.21python3.8.____cpythonpython_implcpython.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '15'
 hdf5:
-- 1.12.2
+- 1.14.1
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_mpimpichnumpy1.21python3.9.____73_pypypython_implpypy.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy1.21python3.9.____73_pypypython_implpypy.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '15'
 hdf5:
-- 1.12.2
+- 1.14.1
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_mpimpichnumpy1.21python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy1.21python3.9.____cpythonpython_implcpython.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '15'
 hdf5:
-- 1.12.2
+- 1.14.1
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_mpimpichnumpy1.23python3.11.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy1.23python3.11.____cpythonpython_implcpython.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '15'
 hdf5:
-- 1.12.2
+- 1.14.1
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_mpinompinumpy1.21python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_mpinompinumpy1.21python3.10.____cpythonpython_implcpython.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '15'
 hdf5:
-- 1.12.2
+- 1.14.1
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_mpinompinumpy1.21python3.8.____73_pypypython_implpypy.yaml
+++ b/.ci_support/osx_64_mpinompinumpy1.21python3.8.____73_pypypython_implpypy.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '15'
 hdf5:
-- 1.12.2
+- 1.14.1
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_mpinompinumpy1.21python3.8.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_mpinompinumpy1.21python3.8.____cpythonpython_implcpython.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '15'
 hdf5:
-- 1.12.2
+- 1.14.1
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_mpinompinumpy1.21python3.9.____73_pypypython_implpypy.yaml
+++ b/.ci_support/osx_64_mpinompinumpy1.21python3.9.____73_pypypython_implpypy.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '15'
 hdf5:
-- 1.12.2
+- 1.14.1
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_mpinompinumpy1.21python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_mpinompinumpy1.21python3.9.____cpythonpython_implcpython.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '15'
 hdf5:
-- 1.12.2
+- 1.14.1
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_mpinompinumpy1.23python3.11.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_mpinompinumpy1.23python3.11.____cpythonpython_implcpython.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '15'
 hdf5:
-- 1.12.2
+- 1.14.1
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_mpiopenmpinumpy1.21python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy1.21python3.10.____cpythonpython_implcpython.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '15'
 hdf5:
-- 1.12.2
+- 1.14.1
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_mpiopenmpinumpy1.21python3.8.____73_pypypython_implpypy.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy1.21python3.8.____73_pypypython_implpypy.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '15'
 hdf5:
-- 1.12.2
+- 1.14.1
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_mpiopenmpinumpy1.21python3.8.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy1.21python3.8.____cpythonpython_implcpython.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '15'
 hdf5:
-- 1.12.2
+- 1.14.1
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_mpiopenmpinumpy1.21python3.9.____73_pypypython_implpypy.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy1.21python3.9.____73_pypypython_implpypy.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '15'
 hdf5:
-- 1.12.2
+- 1.14.1
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_mpiopenmpinumpy1.21python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy1.21python3.9.____cpythonpython_implcpython.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '15'
 hdf5:
-- 1.12.2
+- 1.14.1
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_mpiopenmpinumpy1.23python3.11.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy1.23python3.11.____cpythonpython_implcpython.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '15'
 hdf5:
-- 1.12.2
+- 1.14.1
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_arm64_mpimpichnumpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpimpichnumpy1.21python3.10.____cpython.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '15'
 hdf5:
-- 1.12.2
+- 1.14.1
 macos_machine:
 - arm64-apple-darwin20.0.0
 mpi:

--- a/.ci_support/osx_arm64_mpimpichnumpy1.21python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpimpichnumpy1.21python3.8.____cpython.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '15'
 hdf5:
-- 1.12.2
+- 1.14.1
 macos_machine:
 - arm64-apple-darwin20.0.0
 mpi:

--- a/.ci_support/osx_arm64_mpimpichnumpy1.21python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpimpichnumpy1.21python3.9.____cpython.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '15'
 hdf5:
-- 1.12.2
+- 1.14.1
 macos_machine:
 - arm64-apple-darwin20.0.0
 mpi:

--- a/.ci_support/osx_arm64_mpimpichnumpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpimpichnumpy1.23python3.11.____cpython.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '15'
 hdf5:
-- 1.12.2
+- 1.14.1
 macos_machine:
 - arm64-apple-darwin20.0.0
 mpi:

--- a/.ci_support/osx_arm64_mpinompinumpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpinompinumpy1.21python3.10.____cpython.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '15'
 hdf5:
-- 1.12.2
+- 1.14.1
 macos_machine:
 - arm64-apple-darwin20.0.0
 mpi:

--- a/.ci_support/osx_arm64_mpinompinumpy1.21python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpinompinumpy1.21python3.8.____cpython.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '15'
 hdf5:
-- 1.12.2
+- 1.14.1
 macos_machine:
 - arm64-apple-darwin20.0.0
 mpi:

--- a/.ci_support/osx_arm64_mpinompinumpy1.21python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpinompinumpy1.21python3.9.____cpython.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '15'
 hdf5:
-- 1.12.2
+- 1.14.1
 macos_machine:
 - arm64-apple-darwin20.0.0
 mpi:

--- a/.ci_support/osx_arm64_mpinompinumpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpinompinumpy1.23python3.11.____cpython.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '15'
 hdf5:
-- 1.12.2
+- 1.14.1
 macos_machine:
 - arm64-apple-darwin20.0.0
 mpi:

--- a/.ci_support/osx_arm64_mpiopenmpinumpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpinumpy1.21python3.10.____cpython.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '15'
 hdf5:
-- 1.12.2
+- 1.14.1
 macos_machine:
 - arm64-apple-darwin20.0.0
 mpi:

--- a/.ci_support/osx_arm64_mpiopenmpinumpy1.21python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpinumpy1.21python3.8.____cpython.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '15'
 hdf5:
-- 1.12.2
+- 1.14.1
 macos_machine:
 - arm64-apple-darwin20.0.0
 mpi:

--- a/.ci_support/osx_arm64_mpiopenmpinumpy1.21python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpinumpy1.21python3.9.____cpython.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '15'
 hdf5:
-- 1.12.2
+- 1.14.1
 macos_machine:
 - arm64-apple-darwin20.0.0
 mpi:

--- a/.ci_support/osx_arm64_mpiopenmpinumpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpinumpy1.23python3.11.____cpython.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '15'
 hdf5:
-- 1.12.2
+- 1.14.1
 macos_machine:
 - arm64-apple-darwin20.0.0
 mpi:

--- a/.ci_support/win_64_numpy1.21python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/win_64_numpy1.21python3.10.____cpythonpython_implcpython.yaml
@@ -13,7 +13,7 @@ curl:
 cxx_compiler:
 - vs2019
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - nompi
 mpich:

--- a/.ci_support/win_64_numpy1.21python3.8.____73_pypypython_implpypy.yaml
+++ b/.ci_support/win_64_numpy1.21python3.8.____73_pypypython_implpypy.yaml
@@ -13,7 +13,7 @@ curl:
 cxx_compiler:
 - vs2019
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - nompi
 mpich:

--- a/.ci_support/win_64_numpy1.21python3.8.____cpythonpython_implcpython.yaml
+++ b/.ci_support/win_64_numpy1.21python3.8.____cpythonpython_implcpython.yaml
@@ -13,7 +13,7 @@ curl:
 cxx_compiler:
 - vs2019
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - nompi
 mpich:

--- a/.ci_support/win_64_numpy1.21python3.9.____73_pypypython_implpypy.yaml
+++ b/.ci_support/win_64_numpy1.21python3.9.____73_pypypython_implpypy.yaml
@@ -13,7 +13,7 @@ curl:
 cxx_compiler:
 - vs2019
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - nompi
 mpich:

--- a/.ci_support/win_64_numpy1.21python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/win_64_numpy1.21python3.9.____cpythonpython_implcpython.yaml
@@ -13,7 +13,7 @@ curl:
 cxx_compiler:
 - vs2019
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - nompi
 mpich:

--- a/.ci_support/win_64_numpy1.23python3.11.____cpythonpython_implcpython.yaml
+++ b/.ci_support/win_64_numpy1.23python3.11.____cpythonpython_implcpython.yaml
@@ -13,7 +13,7 @@ curl:
 cxx_compiler:
 - vs2019
 hdf5:
-- 1.12.2
+- 1.14.1
 mpi:
 - nompi
 mpich:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "openpmd-api" %}
 {% set version = "0.15.1" %}
-{% set build = 5 %}
+{% set build = 6 %}
 {% set sha256 = "0e81652152391ba4d2b62cfac95238b11233a4f89ff45e1fcffcc7bcd79dabe1" %}
 
 # ensure mpi is defined (needed for conda-smithy recipe-lint)
@@ -65,7 +65,7 @@ requirements:
     # wrappers are bash scripts and wrappers in build can't use host libraries.
     - openmpi  # [mpi == "openmpi" and (build_platform != target_platform)]
   host:
-    - {{ mpi }}  # [mpi != 'nompi'] 
+    - {{ mpi }}  # [mpi != 'nompi']
     - python
     - pybind11
     - numpy  # for ctest tests


### PR DESCRIPTION
The bot [claims](https://conda-forge.org/status/#hdf51141) that this repo has already been migrated, but no PR was issued. Not sure why it thinks this is the case.

This should get adios2 2.9.1, which has been built with hdf5 1.14.1.